### PR TITLE
chore: use implicit template argument for createBufferFromVector

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.30)
+cmake_minimum_required(VERSION 3.27)
 project(TempleGL)
 set(CMAKE_CXX_STANDARD 23)
 

--- a/src/initializer.cpp
+++ b/src/initializer.cpp
@@ -88,7 +88,7 @@ void Initializer<T>::init() {
     static_cast<Initializer*>(glfwGetWindowUserPointer(w))->cursorPosCallback(static_cast<float>(x),
                                                                               static_cast<float>(y));
   });
-  glfwSetScrollCallback(window_, [](GLFWwindow* w, double x, double y) {
+  glfwSetScrollCallback(window_, [](GLFWwindow* w, double, double y) {
     static_cast<Initializer*>(glfwGetWindowUserPointer(w))->scrollCallback(static_cast<float>(y));
   });
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,5 +9,4 @@ int main() {
     glfwTerminate();
     return -1;
   }
-  return 0;
 }

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -142,9 +142,9 @@ void Model::createBuffers(aiMesh** meshes, const unsigned int num_meshes) {
     }
   }
   num_draw_commands_ = static_cast<GLsizei>(std::ssize(draw_commands));
-  createBufferFromVector<Vertex>(vertex_buffer_, vertices);
-  createBufferFromVector<GLuint>(index_buffer_, indices);
-  createBufferFromVector<DrawElementsIndirectCommand>(draw_command_buffer_, draw_commands);
+  createBufferFromVector(vertex_buffer_, vertices);
+  createBufferFromVector(index_buffer_, indices);
+  createBufferFromVector(draw_command_buffer_, draw_commands);
   glDebugMessageInsert(GL_DEBUG_SOURCE_APPLICATION,
                        GL_DEBUG_TYPE_OTHER,
                        0,
@@ -153,10 +153,9 @@ void Model::createBuffers(aiMesh** meshes, const unsigned int num_meshes) {
                        "(Model::createBuffers): Completed successfully.");
 }
 
-template <typename T>
-void Model::createBufferFromVector(wrap::Buffer& buffer, const std::vector<T>& vector) {
+void Model::createBufferFromVector(wrap::Buffer& buffer, const std::vector<auto>& vector) {
   glCreateBuffers(1, &buffer.id);
-  glNamedBufferStorage(buffer.id, sizeof(T) * std::ssize(vector), vector.data(), GL_DYNAMIC_STORAGE_BIT);
+  glNamedBufferStorage(buffer.id, sizeof(decltype(*vector.begin())) * std::ssize(vector), vector.data(), GL_DYNAMIC_STORAGE_BIT);
 }
 
 void Model::checkAssimpSceneErrors(const aiScene* scene, const std::string& path) const {

--- a/src/model.h
+++ b/src/model.h
@@ -86,8 +86,7 @@ private:
   void loadLightData();
   void createTextureArray(aiMaterial** materials, unsigned int num_materials);
   void createBuffers(aiMesh** meshes, unsigned int num_meshes);
-  template <typename T>
-  static void createBufferFromVector(wrap::Buffer& buffer, const std::vector<T>& vector);
+  static void createBufferFromVector(wrap::Buffer& buffer, const std::vector<auto>& vector);
   void checkAssimpSceneErrors(const aiScene* scene, const std::string& path) const;
 
   static constexpr GLsizei TEX_SIZE {128};


### PR DESCRIPTION
Small change that I never commited for some reason. Modern C++ allows for implicit template arguments, which is much nicer syntax
